### PR TITLE
Add a script to let user sort streamers

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,16 @@
+---
+---
+
+@import "jekyll-theme-hacker";
+
+.streamer-table {
+  th:nth-child(1), th:nth-child(2) {
+    cursor: pointer;
+  }
+}
+th[data-sort="forward"]::after {
+  content: " ▲";
+}
+th[data-sort="backward"]::after {
+  content: " ▼";
+}

--- a/index.md
+++ b/index.md
@@ -146,3 +146,5 @@ Huge shoutout to [chadb_n00b](https://twitch.tv/chadb_n00b) for starting up and 
 ### Report an Issue
 
 Having trouble with a link? Visit the [InfoSec Community Discord](https://discord.gg/RftU46K8sn) and we’ll help you sort it out.
+
+<script src="./js/sort.js" async="" defer=""></script>

--- a/index.tmpl.md
+++ b/index.tmpl.md
@@ -38,3 +38,5 @@ Huge shoutout to [chadb_n00b](https://twitch.tv/chadb_n00b) for starting up and 
 ### Report an Issue
 
 Having trouble with a link? Visit the [InfoSec Community Discord](https://discord.gg/RftU46K8sn) and we’ll help you sort it out.
+
+<script src="./js/sort.js" async="" defer=""></script>

--- a/js/sort.js
+++ b/js/sort.js
@@ -2,6 +2,7 @@
 const table = document.querySelector('table'); // markdown doesn't add ids but we know we want the first table
 table.classList.add('streamer-table');
 
+// Get the initialOrder of rows in table, we can trust this is 2-week activity sorted as it is set by a bot
 const initialOrder = Array.from(table.rows);
 let currentSort = 'initial';
 
@@ -18,7 +19,18 @@ function toggleOnlineSort(headerElement) {
       Array.from(table.rows)
         .map(r => [r, r.querySelector('td:nth-child(1)')?.innerText])
         .filter(r => r[1] !== undefined)
-        .sort((a, b) => a[1].includes('🟢') ? -1 : 1)
+        .sort((a, b) => {
+          if (a[1].includes('🟢') && !b[1].includes('🟢')) {
+            return -1;
+          } else if (b[1].includes('🟢') && !a[1].includes('🟢')) {
+            return 1;
+          }
+
+          const aPos = initialOrder.indexOf(a[0]);
+          const bPos = initialOrder.indexOf(b[0]);
+
+          return aPos-bPos;
+        })
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'online';
       headerElement.setAttribute('data-sort', 'forward');
@@ -27,7 +39,18 @@ function toggleOnlineSort(headerElement) {
       Array.from(table.rows)
         .map(r => [r, r.querySelector('td:nth-child(1)')?.innerText])
         .filter(r => r[1] !== undefined)
-        .sort((a, b) => a[1].includes('🟢') ? 1 : -1)
+        .sort((a, b) => {
+          if (a[1].includes('🟢') && !b[1].includes('🟢')) {
+            return 1;
+          } else if (b[1].includes('🟢') && !a[1].includes('🟢')) {
+            return -1;
+          }
+
+          const aPos = initialOrder.indexOf(a[0]);
+          const bPos = initialOrder.indexOf(b[0]);
+
+          return aPos-bPos;
+        })
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'offline';
       headerElement.setAttribute('data-sort', 'backward');

--- a/js/sort.js
+++ b/js/sort.js
@@ -20,7 +20,7 @@ onlineHeader.addEventListener('click', function(e) {
       Array.from(table.rows)
         .map(r => [r, r.querySelector('td:nth-child(1)')?.innerText])
         .filter(r => r[1] !== undefined)
-        .sort((a, b) => a[1] === '🟢' ? 0 : 1)
+        .sort((a, b) => a[1].includes('🟢') ? -1 : 1)
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'online';
       e.target.setAttribute('data-sort', 'forward');
@@ -29,7 +29,7 @@ onlineHeader.addEventListener('click', function(e) {
       Array.from(table.rows)
         .map(r => [r, r.querySelector('td:nth-child(1)')?.innerText])
         .filter(r => r[1] !== undefined)
-        .sort((a, b) => a[1] === '🟢' ? 1 : 0)
+        .sort((a, b) => a[1].includes('🟢') ? 1 : -1)
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'offline';
       e.target.setAttribute('data-sort', 'backward');

--- a/js/sort.js
+++ b/js/sort.js
@@ -13,6 +13,7 @@ function restoreInitialSort() {
 // Online/Offline sort
 const onlineHeader = table.querySelector('th:nth-child(1)');
 onlineHeader.addEventListener('click', function(e) {
+  document.querySelectorAll('th[data-sort]').forEach(e => e.removeAttribute('data-sort'));
   switch (currentSort) {
     default:
     case 'initial':
@@ -22,7 +23,6 @@ onlineHeader.addEventListener('click', function(e) {
         .sort((a, b) => a[1] === '🟢' ? 0 : 1)
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'online';
-      document.querySelectorAll('td[data-sort]').forEach(e => e.removeAttribute('data-sort'));
       e.target.setAttribute('data-sort', 'forward');
       break;
     case 'online':
@@ -32,7 +32,6 @@ onlineHeader.addEventListener('click', function(e) {
         .sort((a, b) => a[1] === '🟢' ? 1 : 0)
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'offline';
-      document.querySelectorAll('td[data-sort]').forEach(e => e.removeAttribute('data-sort'));
       e.target.setAttribute('data-sort', 'backward');
       break;
     case 'offline':
@@ -47,6 +46,7 @@ onlineHeader.setAttribute('role', 'button');
 // Name sort
 const nameHeader = table.querySelector('th:nth-child(2)');
 nameHeader.addEventListener('click', function(e) {
+  document.querySelectorAll('th[data-sort]').forEach(e => e.removeAttribute('data-sort'));
   switch (currentSort) {
     default:
     case 'initial':
@@ -56,7 +56,6 @@ nameHeader.addEventListener('click', function(e) {
         .sort((a, b) => a[1].localeCompare(b[1]))
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'nameForward';
-      document.querySelectorAll('td[data-sort]').forEach(e => e.removeAttribute('data-sort'));
       e.target.setAttribute('data-sort', 'forward');
       break;
     case 'nameForward':
@@ -66,7 +65,6 @@ nameHeader.addEventListener('click', function(e) {
         .sort((a, b) => b[1].localeCompare(a[1]))
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'nameBackward';
-      document.querySelectorAll('td[data-sort]').forEach(e => e.removeAttribute('data-sort'));
       e.target.setAttribute('data-sort', 'backward');
       break;
     case 'nameBackward':

--- a/js/sort.js
+++ b/js/sort.js
@@ -10,9 +10,7 @@ function restoreInitialSort() {
   currentSort = 'initial';
 }
 
-// Online/Offline sort
-const onlineHeader = table.querySelector('th:nth-child(1)');
-onlineHeader.addEventListener('click', function(e) {
+function toggleOnlineSort(headerElement) {
   document.querySelectorAll('th[data-sort]').forEach(e => e.removeAttribute('data-sort'));
   switch (currentSort) {
     default:
@@ -23,7 +21,7 @@ onlineHeader.addEventListener('click', function(e) {
         .sort((a, b) => a[1].includes('🟢') ? -1 : 1)
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'online';
-      e.target.setAttribute('data-sort', 'forward');
+      headerElement.setAttribute('data-sort', 'forward');
       break;
     case 'online':
       Array.from(table.rows)
@@ -32,13 +30,19 @@ onlineHeader.addEventListener('click', function(e) {
         .sort((a, b) => a[1].includes('🟢') ? 1 : -1)
         .forEach(r => r[0].parentNode.appendChild(r[0]));
       currentSort = 'offline';
-      e.target.setAttribute('data-sort', 'backward');
+      headerElement.setAttribute('data-sort', 'backward');
       break;
     case 'offline':
       restoreInitialSort();
-      e.target.removeAttribute('data-sort');
+      headerElement.removeAttribute('data-sort');
       break;
   }
+}
+
+// Online/Offline sort
+const onlineHeader = table.querySelector('th:nth-child(1)');
+onlineHeader.addEventListener('click', function(e) {
+  toggleOnlineSort(e.target);
 });
 onlineHeader.setAttribute('title', 'Sort by online status');
 onlineHeader.setAttribute('role', 'button');
@@ -75,3 +79,6 @@ nameHeader.addEventListener('click', function(e) {
 });
 nameHeader.setAttribute('title', 'Sort by streamer name');
 nameHeader.setAttribute('role', 'button');
+
+// Initially start in a sort by online state
+toggleOnlineSort(onlineHeader);

--- a/js/sort.js
+++ b/js/sort.js
@@ -1,0 +1,79 @@
+'use strict';
+const table = document.querySelector('table'); // markdown doesn't add ids but we know we want the first table
+table.classList.add('streamer-table');
+
+const initialOrder = Array.from(table.rows);
+let currentSort = 'initial';
+
+function restoreInitialSort() {
+  initialOrder.forEach(e => e.parentNode.appendChild(e));
+  currentSort = 'initial';
+}
+
+// Online/Offline sort
+const onlineHeader = table.querySelector('th:nth-child(1)');
+onlineHeader.addEventListener('click', function(e) {
+  switch (currentSort) {
+    default:
+    case 'initial':
+      Array.from(table.rows)
+        .map(r => [r, r.querySelector('td:nth-child(1)')?.innerText])
+        .filter(r => r[1] !== undefined)
+        .sort((a, b) => a[1] === '🟢' ? 0 : 1)
+        .forEach(r => r[0].parentNode.appendChild(r[0]));
+      currentSort = 'online';
+      document.querySelectorAll('td[data-sort]').forEach(e => e.removeAttribute('data-sort'));
+      e.target.setAttribute('data-sort', 'forward');
+      break;
+    case 'online':
+      Array.from(table.rows)
+        .map(r => [r, r.querySelector('td:nth-child(1)')?.innerText])
+        .filter(r => r[1] !== undefined)
+        .sort((a, b) => a[1] === '🟢' ? 1 : 0)
+        .forEach(r => r[0].parentNode.appendChild(r[0]));
+      currentSort = 'offline';
+      document.querySelectorAll('td[data-sort]').forEach(e => e.removeAttribute('data-sort'));
+      e.target.setAttribute('data-sort', 'backward');
+      break;
+    case 'offline':
+      restoreInitialSort();
+      e.target.removeAttribute('data-sort');
+      break;
+  }
+});
+onlineHeader.setAttribute('title', 'Sort by online status');
+onlineHeader.setAttribute('role', 'button');
+
+// Name sort
+const nameHeader = table.querySelector('th:nth-child(2)');
+nameHeader.addEventListener('click', function(e) {
+  switch (currentSort) {
+    default:
+    case 'initial':
+      Array.from(table.rows)
+        .map(r => [r, r.querySelector('td:nth-child(2)')?.innerText?.toLowerCase()])
+        .filter(r => r[1] !== undefined)
+        .sort((a, b) => a[1].localeCompare(b[1]))
+        .forEach(r => r[0].parentNode.appendChild(r[0]));
+      currentSort = 'nameForward';
+      document.querySelectorAll('td[data-sort]').forEach(e => e.removeAttribute('data-sort'));
+      e.target.setAttribute('data-sort', 'forward');
+      break;
+    case 'nameForward':
+      Array.from(table.rows)
+        .map(r => [r, r.querySelector('td:nth-child(2)')?.innerText?.toLowerCase()])
+        .filter(r => r[1] !== undefined)
+        .sort((a, b) => b[1].localeCompare(a[1]))
+        .forEach(r => r[0].parentNode.appendChild(r[0]));
+      currentSort = 'nameBackward';
+      document.querySelectorAll('td[data-sort]').forEach(e => e.removeAttribute('data-sort'));
+      e.target.setAttribute('data-sort', 'backward');
+      break;
+    case 'nameBackward':
+      restoreInitialSort();
+      e.target.removeAttribute('data-sort');
+      break;
+  }
+});
+nameHeader.setAttribute('title', 'Sort by streamer name');
+nameHeader.setAttribute('role', 'button');


### PR DESCRIPTION
This PR adds a script that allows users to click some of the table headings (online, streamer) and sort the list. I believe this makes the list easier to use as you can quickly sort online streamers to the top. The javascript is not that nice but it works :).