### PR TITLE
Prevent text in table headers from wrapping onto a newline

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -8,9 +8,15 @@
     cursor: pointer;
   }
 }
+
+th {
+  white-space: nowrap;
+}
+
 th[data-sort="forward"]::after {
   content: " ▲";
 }
+
 th[data-sort="backward"]::after {
   content: " ▼";
 }


### PR DESCRIPTION
This makes the table look slightly nicer in my opinion. Especially when
sorting the list.