### PR TITLE
Add responsive styling and improve layout for mobile

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -14,6 +14,14 @@
     white-space: nowrap;
   }
 
+  th:nth-child(1)::before {
+    content: "Online";
+  }
+
+  th::after {
+    content: "  ";
+  }
+
   th[data-sort="forward"]::after {
     content: " ▲";
   }
@@ -44,6 +52,10 @@
   .streamer-table {
     th:nth-child(4), td:nth-child(4) {
       display:none;
+    }
+
+    th:nth-child(1)::before {
+      content: "🟢";
     }
   }
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -38,3 +38,12 @@
 [role=modal] > * {
   background: $body-background;
 }
+
+/* Rules for small screens */
+@media (max-width: 700px) {
+  .streamer-table {
+    th:nth-child(4), td:nth-child(4) {
+      display:none;
+    }
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,7 +4,7 @@
 @import "jekyll-theme-hacker";
 
 .streamer-table {
-  table-layout: fixed;
+  table-layout: auto;
   
   th[role=button] {
     cursor: pointer;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -11,7 +11,7 @@
   }
 
   th {
-    white-space: nowrap;
+    white-space: pre-wrap;
   }
 
   th:nth-child(1)::before {

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ Please contribute missing streams or errors via a [pull request](https://github.
 
 ## List of Streams (sorted)
 
-Online | <i class="fas fa-headset"></i> | <i class="fas fa-external-link-alt"></i> | <i class="fas fa-comment-dots"></i>
+&nbsp; | <i class="fas fa-headset"></i> | <i class="fas fa-external-link-alt"></i> | <i class="fas fa-comment-dots"></i>
 ---: | --- | :--- | :---
 &nbsp; | `Security_Live` | [<i class="fab fa-twitch" style="color:#9146FF"></i>](https://www.twitch.tv/Security_Live) &nbsp; [<i class="fab fa-youtube" style="color:#C00"></i>](https://www.youtube.com/channel/UCMDy1HAPNcpl8zVTK1NfMqw) |
 &nbsp; | `OCEANSGIANT` | [<i class="fab fa-twitch" style="color:#9146FF"></i>](https://www.twitch.tv/OCEANSGIANT) &nbsp; |

--- a/index.tmpl.md
+++ b/index.tmpl.md
@@ -8,7 +8,7 @@ Please contribute missing streams or errors via a [pull request](https://github.
 
 ## List of Streams (sorted)
 
-Online | <i class="fas fa-headset"></i> | <i class="fas fa-external-link-alt"></i> | <i class="fas fa-comment-dots"></i>
+&nbsp; | <i class="fas fa-headset"></i> | <i class="fas fa-external-link-alt"></i> | <i class="fas fa-comment-dots"></i>
 ---: | --- | :--- | :---
 
 ### Useful links


### PR DESCRIPTION
When screen width is less than 700px:
- Hide the language column
- Change the title of the online column to a single emoji

Also change table sizing from `fixed` to `auto`, this means the browser automatically sizes the columns, leading to name having a wider column (still few issues with this).

Not sure if I modified the page template correctly so maybe check that.

A live example is at https://douile.github.io/infosecstreams.github.io/