### PR TITLE
Update streamers.csv - Changing youtube channel to my live one

### DIFF
--- a/streamers.csv
+++ b/streamers.csv
@@ -104,7 +104,7 @@ f3rn0s_sec,
 fearless0523,
 FinnWithGun,
 firzen14,
-FixIt42,https://www.youtube.com/@FixIt42
+FixIt42,https://www.youtube.com/@FixIt42live
 Flangvik,
 Fluxxset,
 footpics4sale,


### PR DESCRIPTION
Switching to my live youtube channel after twitch's new highlight limitation. I'd love the possibility to add two youtube channels

FixIt42,https://www.youtube.com/@FixIt42
to
FixIt42,https://www.youtube.com/@FixIt42live